### PR TITLE
Improve selectability of terminal commands in `term` tag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 rendered
 dist
 pyradium.egg-info/
+venv

--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ pyradium is available on PyPi, so installation is as easy as
 $ pip3 install pyradium
 ```
 
-For usage of LaTeX style presentations, you need pdflatex and ImageMagick. To
-use continuous building, pyradium relies on the inotifytools.:
+For usage of LaTeX style presentations, you need pdflatex and ImageMagick. For some SVGs you need Inkscape.
+For plotting you need gnuplot.
+To use continuous building, pyradium relies on the inotifytools.:
 
 ```
-# apt-get install texlive texlive-latex-extra imagemagick inotify-tools
+# apt-get install texlive texlive-latex-extra imagemagick inkscape gnuplot inotify-tools
 ```
 
 You also need to tell ImageMagick to permit PDF to raster image conversion by removing (or commenting out) the line

--- a/examples/example.xml
+++ b/examples/example.xml
@@ -175,10 +175,16 @@
 
 	<slide>
 		<s:var name="heading" value="Some Terminal"/>
-		<s:term><![CDATA[
+		<s:term prompt="$ "><![CDATA[
 			$ ls /
 			bin
 			sbin
+			$ cat /var/log/auth.log \
+				| sed -rn 's/.*Failed password for invalid user (\w*?) from.*/\1/p' \
+				| sort \
+				| uniq \
+				| wc -l
+			3332
 		]]></s:term>
 	</slide>
 

--- a/pyradium/templates/base/pyradium.css
+++ b/pyradium/templates/base/pyradium.css
@@ -116,6 +116,10 @@ pre.terminal {
 	overflow-x: auto;
 }
 
+pre.terminal .command {
+	user-select: all;
+}
+
 div.code_highlight {
 	background: #eee;
 	border: 1px gray dotted;

--- a/pyradium/xmlhooks/TerminalHook.py
+++ b/pyradium/xmlhooks/TerminalHook.py
@@ -19,7 +19,6 @@
 #
 #	Johannes Bauer <JohannesBauer@gmx.de>
 
-from dataclasses import replace
 from pyradium.xmlhooks.XMLHookRegistry import InnerTextHook, XMLHookRegistry
 
 @XMLHookRegistry.register_hook

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
 	install_requires = [
 		"mako",
 		"pygments",
+		"requests",
 	],
 	entry_points = {
 		"console_scripts": [


### PR DESCRIPTION
Any `term` tag with attribute `prompt` will now interpret lines starting with that prompt as commands. Multiline is supported (by detecting trailing backslashes). These detected commands will then get a `command` class which has 

```css
pre.terminal .command {
	user-select: all;
}
```

Doesn't directly add copy/paste functionality like specified in #12 but copying is now as simple as "click and Ctrl+C", which imo is an improvement.

Demo is in the example.xml and here: https://pyradium.dev.frereit.de/#slide20


Also adds some dependencies that were missing from the setup.py and README.
