### PR TITLE
Fix s:verb replacing endash/emdash

### DIFF
--- a/pyradium/xmlhooks/XMLHookRegistry.py
+++ b/pyradium/xmlhooks/XMLHookRegistry.py
@@ -77,7 +77,7 @@ class XMLHookRegistry():
 				new_text = cls._replace_text(text)
 				if text != new_text:
 					node.replaceWholeText(new_text)
-		XMLTools.walk(root_node, callback)
+		XMLTools.walk(root_node, callback, cancel_descent_predicate=lambda node: node.nodeName == "s:verb")
 
 class BaseHook():
 	_TAG_NAME = None


### PR DESCRIPTION
Modifying the
https://github.com/johndoe31415/pyradium/blob/18176d648d15e508d72b2ed255e8ced43e24f02a/pyradium/xmlhooks/XMLHookRegistry.py#L80 method call and setting
```py
XMLTools.walk(root_node, callback, cancel_descent_predicate=lambda node: node.nodeName == "s:verb")
```
solves the described issue.
https://github.com/johndoe31415/pyradium/blob/18176d648d15e508d72b2ed255e8ced43e24f02a/pyradium/Tools.py#L90-L96 Here - calling the method for the first time - no `cancel_descent_predicate` function is set. As each `s:verb` element itself contains a text element, the `.walk` method also calls the `callback` on each text element - not being stopped by the following line as `continue_descent_with_replaced_elements` is evaluated as `False`. This causes the `.walk` method to continue stepping into the child nodes - `Text` in this case.
https://github.com/johndoe31415/pyradium/blob/18176d648d15e508d72b2ed255e8ced43e24f02a/pyradium/xmlhooks/XMLHookRegistry.py#L67 I tried fixing this by implementing a `.walk` in a newly created `else` branch but this does not seem to do the trick - also complicating the code at the same time. Thus, changing the code to the above suggestion seems to be the best alternative.
Using the constant
https://github.com/johndoe31415/pyradium/blob/18176d648d15e508d72b2ed255e8ced43e24f02a/pyradium/xmlhooks/XMLHookRegistry.py#L32 would also stop the `s:term` and `s:code` from being rendered correctly, thus this is no solution either.

Looking forward to your comment on this.

Closes #56 