### PR TITLE
Remove border around slides in fullscreen mode

### DIFF
--- a/pyradium/templates/base/pyradium.css
+++ b/pyradium/templates/base/pyradium.css
@@ -5,9 +5,12 @@ body {
 div.size_container {
 	width: ${renderer.rendering_params.geometry_x}px;
 	height: ${renderer.rendering_params.geometry_y}px;
-	border: 1px solid #aaa;
 	margin-bottom: 10px;
 	overflow: hidden;
+}
+
+div.size_container:not(.fullscreen){
+	border: 1px solid #aaa;
 }
 
 a.slideanchor {


### PR DESCRIPTION
Fixes #58

This fix would only apply the border to all regular slide-containers `.size_container` that are not the full-screen container (those can be identified by `:not(.fullscreen)`)

The cursor appearance seems to be modified with JS, which is not necessary for this issue.