### PR TITLE
Fix botched break dialog

### DIFF
--- a/pyradium/templates/antonio/configuration.json
+++ b/pyradium/templates/antonio/configuration.json
@@ -153,7 +153,7 @@
 					"base/presentation_pause_end.mp3"
 				],
 				"css": [
-					"base/pyradium_modal.css",
+					"base/pyradium_dialog.css",
 					"base/pyradium_pause.css"
 				]
 			},

--- a/pyradium/templates/base/index.html
+++ b/pyradium/templates/base/index.html
@@ -61,26 +61,26 @@
 			</script>
 %endif
 %if rendered_presentation.has_feature("pause"):
-			<div class="modal type-info fixed" id="pyradium_pause_popup">
-				<div class="content">
-					<span class="close">×</span>
-					<div class="msg">
-						<div class="pause_duration">
-							Pause for <span id="pause_duration"></span> minutes until <span id="pause_until"></span>.
-						</div>
-						<div class="pause_remaining">
-							Remaining: <span id="pause_remaining"></span>
-						</div>
+			<dialog id="pyradium_pause_popup">
+				<div class="header">
+					<span class="placeholder"></span>
+					<span class="icon">☕</span>
+					<button autofocus class="close">×</button>
+				</div>
+
+				<div class="body">
+					<div class="pause_duration">
+						Pause for <span id="pause_duration"></span> minutes until <span id="pause_until"></span>.
+					</div>
+					<div class="pause_remaining">
+						Remaining: <span id="pause_remaining"></span>
 					</div>
 				</div>
-			</div>
+			</dialog>
 
 			<script type="module">
-				import {ModalWindow} from "${preuri_ds}template/base/pyradium_modal.js";
-				const modal_div = document.querySelector("#pyradium_pause_popup");
-				modal_div.pyradium_modal = new ModalWindow(modal_div, {
-					close_on_popup_click:	false,
-				});
+				const modal = document.querySelector("#pyradium_pause_popup");
+				modal.querySelector(".close").addEventListener("click", () => modal.close());
 			</script>
 %endif
 

--- a/pyradium/templates/base/pyradium.js
+++ b/pyradium/templates/base/pyradium.js
@@ -436,8 +436,9 @@ export class Presentation {
 	}
 
 	pause() {
-		const modal_div = this._ui_elements.pause_modal;
-		if (modal_div.active) {
+		/** @type {HTMLDialogElement} */
+		const modal = this._ui_elements.pause_modal;
+		if (modal.open) {
 			return;
 		}
 
@@ -449,22 +450,19 @@ export class Presentation {
 		let pause_parameters = {
 			"pause_duration_secs":		pause_duration_mins * 60,
 			"pause_start_secs":			new Date().getTime() / 1000,
-			"pause_remaining_span":		modal_div.querySelector("#pause_remaining"),
+			"pause_remaining_span":		modal.querySelector("#pause_remaining"),
 			"expired":					false,
 		}
 
-		const modal = modal_div.pyradium_modal;
-		modal_div.querySelector("#pause_duration").innerText = pause_duration_mins;
+		modal.querySelector("#pause_duration").innerText = pause_duration_mins;
 
 		const pause_until = new Date((pause_parameters.pause_start_secs + pause_parameters.pause_duration_secs) * 1000);
-		modal_div.querySelector("#pause_until").innerText = TimeTools.format_datetime(pause_until).hms
+		modal.querySelector("#pause_until").innerText = TimeTools.format_datetime(pause_until).hms
 
 		this._pause_tick(pause_parameters);
 		const interval_id = setInterval(() => this._pause_tick(pause_parameters), 1000);
 
-		modal.on_close = () => {
-			clearInterval(interval_id);
-		};
-		modal.show();
+		modal.addEventListener("close", () => clearInterval(interval_id));
+		modal.showModal();
 	}
 }

--- a/pyradium/templates/base/pyradium_dialog.css
+++ b/pyradium/templates/base/pyradium_dialog.css
@@ -1,0 +1,46 @@
+dialog {
+	border: none;
+	border-radius: 7px;
+	padding: 20px;
+	border: 7px solid #aaa;
+}
+
+::backdrop {
+	background: rgba(0, 0, 0, 0.45);
+}
+
+dialog .header {
+	width: 100%;
+	display: flex;
+	justify-content: space-between;
+	flex-flow: row nowrap;
+}
+
+dialog .close {
+	font-size: 32px;
+	padding: 0;
+	margin: 0;
+	border: none;
+	background-color: inherit;
+	font-weight: bold;
+	width: 48px;
+	height: 48px;
+	opacity: 0.5;
+}
+
+dialog .close:hover {
+	opacity: 1;
+}
+
+dialog .placeholder {
+	width: 48px;
+}
+
+dialog .icon {
+	font-size: 192px;
+	padding: 15px;
+}
+
+dialog .body {
+	padding: 45px;
+}


### PR DESCRIPTION
Use html `<dialog>` element instead of a custom written dialog whose backdrop does not cover 100% of the UI.
Additionally, some minor design improvements have been added.

Unfortunately, I am not able to further maintain this dialog because of the ugly blue border around the dialog which adds extreme complexity to the construct. Hope this still meets your expectations.

Fixes #63.