### PR TITLE
Fix non-functional buttons when rendering without the timer

### DIFF
--- a/pyradium/templates/antonio/configuration.json
+++ b/pyradium/templates/antonio/configuration.json
@@ -59,6 +59,7 @@
 		],
 		"static": [
 			"base/pyradium.js",
+			"base/pyradium_tools.js",
 			"base/cursor_circle.svg",
 			"base/cursor_arrow.svg",
 			"antonio/bar.svg",
@@ -145,7 +146,6 @@
 				"static": [
 					"base/timer.html",
 					"base/pyradium_timer.js",
-					"base/pyradium_tools.js",
 					"base/media_stop.svg",
 					"base/media_pause.svg",
 					"base/media_play.svg",


### PR DESCRIPTION
Moved the `pyradium_tools.js` from feature:timer to files:static so the file is always included into the rendered presentation.

Fixes #73 